### PR TITLE
get gpu name for linux systems without pcie gpus

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2499,6 +2499,12 @@ get_gpu() {
                                       print a[i]
                                   }
                               }}')"
+
+            if [[ "$gpu_cmd" == "" ]]; then
+                gpu_cmd="$(glxinfo -B | grep -F 'OpenGL renderer string')"
+                gpu_cmd="${gpu_cmd/OpenGL renderer string: }"
+            fi
+
             IFS=$'\n' read -d "" -ra gpus <<< "$gpu_cmd"
 
             # Remove duplicate Intel Graphics outputs.
@@ -2532,6 +2538,7 @@ get_gpu() {
                     ;;
 
                     *"NVIDIA"*)
+                        gpu="${gpu/*NVIDIA}"
                         gpu="${gpu/*\[}"
                         gpu="${gpu/\]*}"
                         gpu="NVIDIA $gpu"


### PR DESCRIPTION
allows for detection of the nvidia jetson and similar other gpus which have no pcie connection

## Description

Only fill in the fields below if relevant.


## Features

## Issues

## TODO
